### PR TITLE
INTERLOK-3247 Use RemoteBlobIterableImpl to lazily iterate over blobs.

### DIFF
--- a/interlok-jclouds-blobstore/build.gradle
+++ b/interlok-jclouds-blobstore/build.gradle
@@ -58,6 +58,8 @@ publishing {
         properties.appendNode("tags", "s3,backblaze,azure blob,google cloud storage,rackspace")
         properties.appendNode("license", "false")
         properties.appendNode("externalUrl", "https://jclouds.apache.org/")
+        properties.appendNode("readme", "https://github.com/adaptris/interlok-jclouds/raw/develop/README.md")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-jclouds")   
       }
     }
   }

--- a/interlok-jclouds-blobstore/src/main/java/com/adaptris/jclouds/blobstore/ListOperation.java
+++ b/interlok-jclouds-blobstore/src/main/java/com/adaptris/jclouds/blobstore/ListOperation.java
@@ -15,12 +15,15 @@
 */
 package com.adaptris.jclouds.blobstore;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
-import org.apache.commons.lang3.StringUtils;
+import java.util.Optional;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jclouds.blobstore.BlobStore;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
@@ -34,6 +37,7 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.interlok.cloud.BlobListRenderer;
 import com.adaptris.interlok.cloud.RemoteBlob;
 import com.adaptris.interlok.cloud.RemoteBlobFilter;
+import com.adaptris.interlok.util.CloseableIterable;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
 import lombok.Setter;
@@ -92,36 +96,10 @@ public class ListOperation extends ContainerOperation {
   public void execute(BlobStoreConnection conn, AdaptrisMessage msg) throws Exception {
     String container = msg.resolve(getContainerName());
     BlobStore store = conn.getBlobStore(container);
-    outputStyle().render(list(store, container, msg), msg);
+    String prefix = msg.resolve(getPrefix());
+    outputStyle().render(new RemoteBlobIterable(store, container, prefix, blobFilter()), msg);
   }
 
-  private Collection<RemoteBlob> list(BlobStore store, String container, AdaptrisMessage msg) throws Exception {
-    List<RemoteBlob> blobs = new ArrayList<>();
-    String marker = null;
-    RemoteBlobFilter filter = blobFilter();
-    do {
-      PageSet<? extends StorageMetadata> bloblist = store.list(container, buildListOptions(msg, marker));
-      for (StorageMetadata meta : bloblist) {
-        RemoteBlob blob = new RemoteBlob.Builder().setBucket(container).setLastModified(meta.getLastModified().getTime())
-            .setName(meta.getName()).setSize(meta.getSize()).build();
-        // Only accept if it's a blob, rather than a directory or similar.
-        if (BooleanUtils.and(new boolean[] {filter.accept(blob), meta.getType() == StorageType.BLOB})) {
-          blobs.add(blob);
-        }
-      }
-      marker = bloblist.getNextMarker();
-    } while (marker != null);
-    return blobs;
-  }
-
-  private ListContainerOptions buildListOptions(AdaptrisMessage msg, String marker) {
-    String pfx = StringUtils.defaultIfEmpty(msg.resolve(getPrefix()), "");
-    ListContainerOptions options = ListContainerOptions.Builder.prefix(pfx);
-    if (marker != null) {
-      options = options.afterMarker(marker);
-    }
-    return options;
-  }
 
   public ListOperation withFilter(RemoteBlobFilter s) {
     setFilter(s);
@@ -145,4 +123,5 @@ public class ListOperation extends ContainerOperation {
   private RemoteBlobFilter blobFilter() {
     return ObjectUtils.defaultIfNull(getFilter(), (blob) -> true);
   }
+
 }

--- a/interlok-jclouds-blobstore/src/main/java/com/adaptris/jclouds/blobstore/RemoteBlobIterable.java
+++ b/interlok-jclouds-blobstore/src/main/java/com/adaptris/jclouds/blobstore/RemoteBlobIterable.java
@@ -1,0 +1,78 @@
+package com.adaptris.jclouds.blobstore;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.domain.PageSet;
+import org.jclouds.blobstore.domain.StorageMetadata;
+import org.jclouds.blobstore.domain.StorageType;
+import org.jclouds.blobstore.options.ListContainerOptions;
+import com.adaptris.interlok.cloud.RemoteBlob;
+import com.adaptris.interlok.cloud.RemoteBlobFilter;
+import com.adaptris.interlok.cloud.RemoteBlobIterableImpl;
+import com.adaptris.util.NumberUtils;
+
+class RemoteBlobIterable extends RemoteBlobIterableImpl<StorageMetadata> {
+
+  private RemoteBlobFilter blobFilter = null;
+  private BlobStore blobStorage;
+  private String containerName;
+  private String blobPrefix;
+  private PageSet<? extends StorageMetadata> currentPage;
+  private Iterator<? extends StorageMetadata> pageIterator;
+
+  protected RemoteBlobIterable(BlobStore store, String container, String prefix, RemoteBlobFilter filter) {
+    this.blobStorage = store;
+    this.containerName = container;
+    this.blobPrefix = prefix;
+    this.blobFilter = filter;
+  }
+
+  @Override
+  protected void iteratorInit() {
+    currentPage = blobStorage.list(containerName, buildListOptions(blobPrefix, null));
+    pageIterator = currentPage.iterator();
+  }
+
+  @Override
+  protected Optional<StorageMetadata> nextStorageItem() throws NoSuchElementException {
+    if (!pageIterator.hasNext()) {
+      advanceToNextPage();
+    }
+    return Optional.ofNullable(pageIterator.next());
+  }
+  
+  private void advanceToNextPage() throws NoSuchElementException {
+    String hasNextPage = currentPage.getNextMarker();
+    if (hasNextPage == null) {
+      throw new NoSuchElementException();
+    }
+    currentPage = blobStorage.list(containerName, buildListOptions(blobPrefix, hasNextPage));
+    pageIterator = currentPage.iterator();
+  }
+  
+  @Override
+  protected Optional<RemoteBlob> accept(StorageMetadata meta) {
+    RemoteBlob blob = new RemoteBlob.Builder().setBucket(containerName).setLastModified(meta.getLastModified().getTime())
+        .setName(meta.getName()).setSize(NumberUtils.toLongDefaultIfNull(meta.getSize(), -1)).build();
+    // Only accept if it's a blob, rather than a directory or similar.
+    if (BooleanUtils.and(new boolean[] {blobFilter.accept(blob), meta.getType() == StorageType.BLOB})) {
+      return Optional.of(blob);
+    }
+    return Optional.empty();      
+  }
+
+  private ListContainerOptions buildListOptions(String prefix, String marker) {
+    String pfx = StringUtils.defaultIfEmpty(prefix, "");
+    ListContainerOptions options = ListContainerOptions.Builder.prefix(pfx);
+    if (marker != null) {
+      options = options.afterMarker(marker);
+    }
+    return options;
+  }
+}
+
+

--- a/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/OperationCase.java
+++ b/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/OperationCase.java
@@ -49,4 +49,11 @@ public abstract class OperationCase {
     builder.payload(content);
     store.putBlob(container, builder.build());
   }
+  
+  public static void createBlobs(BlobStoreContext context, String container, int count, String suffix) {
+    for (int i = 0; i < count; i++) {
+      createBlob(context, container, guid.safeUUID() + suffix, "hello world");
+    }
+  }
+
 }

--- a/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/RemoteBlobIterableTest.java
+++ b/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/RemoteBlobIterableTest.java
@@ -1,0 +1,55 @@
+package com.adaptris.jclouds.blobstore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.util.Iterator;
+import org.jclouds.blobstore.BlobStore;
+import org.junit.Test;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.cloud.RemoteBlob;
+
+public class RemoteBlobIterableTest extends OperationCase {
+
+  
+  @Test
+  public void testIterator() throws Exception {
+    String container = guid.safeUUID();
+    BlobStoreConnection con = createConnection();
+    try {
+      LifecycleHelper.initAndStart(con);
+      createBlobs(con.getBlobStoreContext(), container, 5, ".txt");
+      createBlobs(con.getBlobStoreContext(), container, 5, ".json");
+      BlobStore store = con.getBlobStore(container);
+      RemoteBlobIterable iterable = new RemoteBlobIterable(store, container, "", (f) -> true);
+      Iterator<RemoteBlob> i = iterable.iterator();
+      int count = 0;
+      assertTrue(i.hasNext());
+      while (i.hasNext()) {
+        RemoteBlob blob = i.next();
+        count++;        
+      }
+      assertEquals(10, count);
+    } finally {
+      LifecycleHelper.stopAndClose(con);
+    }
+  }
+
+  @Test(expected=IllegalStateException.class)
+  public void testIterator_Double() throws Exception {
+    String container = guid.safeUUID();
+    BlobStoreConnection con = createConnection();
+    try {
+      LifecycleHelper.initAndStart(con);
+      createBlobs(con.getBlobStoreContext(), container, 5, ".txt");
+      createBlobs(con.getBlobStoreContext(), container, 5, ".json");
+      BlobStore store = con.getBlobStore(container);
+      RemoteBlobIterable iterable = new RemoteBlobIterable(store, container, "", (f) -> true);
+      iterable.iterator();
+      // double iterator == IllegalStateException
+      iterable.iterator();
+    } finally {
+      LifecycleHelper.stopAndClose(con);
+    }
+  }
+  
+}


### PR DESCRIPTION
## Motivation

Previously, BlobListRenderer took a collection as its input for rendering into a message. Since there is technically no limit to the number of blob entries in remote storage (e.g. in an S3 bucket) you could end up creating a list with a huge number of entries ('00000s) which has a cost in terms of memory, performance and garbage collection.

## Modification

### Upstream/Peer projects

- BlobListRenderer in interlok-common had its interface changed to Iterable<RemoteBlob> : https://github.com/adaptris/interlok/commit/6011b7494144cf36dd9c9b73a73aba888e875bb1
- A new class RemoteBlobIterableImpl was added to interlok-common to assist with iterating over remote blobs : https://github.com/adaptris/interlok/commit/6504fd9abfa7bee1e5554dfc00f28dd37b027b79
- JsonBlobRenderer was changed to fit the new interface : https://github.com/adaptris/interlok-json/commit/9499e0b9fe8eedbbb20f5ed51109ac0e10d87c7a
- CSVBlobRenderer was changed to fit the new interface : https://github.com/adaptris/interlok-csv/commit/2ad459ab104a38c4c6dee41a8a9368581fd81d8c

### interlok-jclouds
BlobListRenderer had its interface changed to Iterable<RemoteBlob> (not part of this PR) : https://github.com/adaptris/interlok/commit/6011b7494144cf36dd9c9b73a73aba888e875bb1

A new class RemoteBlobIterableImpl was added to interlok-common to assist with iterating over remote blobs (not part of this PR).  : https://github.com/adaptris/interlok/commit/6504fd9abfa7bee1e5554dfc00f28dd37b027b79

- A new class RemoteBlobIterable was that extends RemoteBlobIterableImpl and iterates over the underlying jclouds Pageset handling pagination silently.

- ListOperation switched to using the Iterable implementation rather than reading all the remote blobs into a big old list.

## Result

Transparent to the end-user. Since there were no changes to existing tests, it suggests that there are no regressions.

## Testing

You can test by using the jclouds  to iterate over the filesystem (you will need `org.apache.jclouds.api:filesystem:2.2.1` as well as interlok-jclouds-blobstore)

- Create a `/opt/interlok/fs` directory
- Create a subdirectory (this will be your "container") - `MyBucket`
- Fill it with files.


```
  <jclouds-blobstore-service>
   <connection class="jclouds-blobstore-connection">
    <provider>filesystem</provider>
    <configuration>
     <key-value-pair>
      <key>jclouds.filesystem.basedir</key>
      <value>/opt/interlok/fs</value>
     </key-value-pair>
    </configuration>
   </connection>
   <operation class="jclouds-blobstore-list">
       <container-name>MyBucket</container-name>
       <output-style class="remote-blob-list-as-json"/>
   </operation>
</jclouds-blobstore-service>
```
