### PR TITLE
INTERLOK-3303 Add support for STS as credentials

### DIFF
--- a/interlok-jclouds-aws-sts/build.gradle
+++ b/interlok-jclouds-aws-sts/build.gradle
@@ -1,12 +1,11 @@
 ext {
-  componentName='Interlok/Apache jclouds blobstore'
+  componentName='Interlok/Apache JClouds STS'
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
 }
 
 dependencies {
   compile project(":interlok-jclouds-common")
-  compile ("org.apache.jclouds:jclouds-blobstore:$jcloudsVersion")
-  testImplementation "org.apache.jclouds.api:filesystem:$jcloudsVersion"
+  compile ("org.apache.jclouds.api:sts:$jcloudsVersion")
 }
 
 
@@ -26,11 +25,6 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 
-task examplesJar(type: Jar, dependsOn: test) {
-    classifier = 'examples'
-    from new File(buildDir, '/examples')
-}
-
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
     from sourceSets.main.extensions.delombokTask
@@ -38,7 +32,6 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 
 artifacts {
   archives javadocJar
-  archives examplesJar
   archives sourcesJar
 }
 
@@ -48,18 +41,17 @@ publishing {
     mavenJava(MavenPublication) {
       from components.java
       artifact javadocJar { classifier "javadoc" }
-      artifact examplesJar { classifier "examples" }
       artifact sourcesJar { classifier "sources" }
       pom.withXml {
-        asNode().appendNode("description", "Use Apache jclouds to access your cloud storage")
+        asNode().appendNode("description", "Connect using Apache JClouds to AWS Services using AWS Secure Token Service")
         asNode().appendNode("name", componentName)
         def properties = asNode().appendNode("properties")
-        properties.appendNode("target", "3.7.3+")
-        properties.appendNode("tags", "s3,backblaze,azure blob,google cloud storage,rackspace")
+        properties.appendNode("target", "3.10.2+")
+        properties.appendNode("tags", "aws sts,aws,jclouds")
         properties.appendNode("license", "false")
         properties.appendNode("externalUrl", "https://jclouds.apache.org/")
         properties.appendNode("readme", "https://github.com/adaptris/interlok-jclouds/raw/develop/README.md")
-        properties.appendNode("repository", "https://github.com/adaptris/interlok-jclouds")   
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-jclouds")
       }
     }
   }
@@ -84,4 +76,3 @@ task deleteGeneratedFiles(type: Delete) {
 
 clean.dependsOn deleteGeneratedFiles
 javadoc.dependsOn offlinePackageList
-

--- a/interlok-jclouds-aws-sts/src/main/java/com/adaptris/jclouds/sts/SessionTokenCredentialsBuilder.java
+++ b/interlok-jclouds-aws-sts/src/main/java/com/adaptris/jclouds/sts/SessionTokenCredentialsBuilder.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package com.adaptris.jclouds.sts;
+
+import org.jclouds.aws.domain.SessionCredentials;
+import org.jclouds.domain.Credentials;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.interlok.resolver.ExternalResolver;
+import com.adaptris.jclouds.common.DefaultCredentialsBuilder;
+import com.adaptris.security.exc.PasswordException;
+import com.adaptris.security.password.Password;
+import com.google.common.base.Supplier;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.SneakyThrows;
+
+/**
+ * AWS STS Credentials Provider
+ * 
+ * 
+ * @config jclouds-sts-credentials-builder
+ *
+ */
+@XStreamAlias("jclouds-sts-credentials-builder")
+@DisplayOrder(order =
+{
+    "identity", "credentials", "sessionToken"
+})
+@ComponentProfile(summary = "Provide credentials via Amazon STS")
+public class SessionTokenCredentialsBuilder extends DefaultCredentialsBuilder {
+
+  /**
+   * Set the session token required.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(style = "PASSWORD", external = true)
+  private String sessionToken;
+
+
+  @Override
+  public Supplier<Credentials> build() {
+    return () -> credentials();
+  }
+
+
+  @SuppressWarnings("unchecked")
+  public <T extends SessionTokenCredentialsBuilder> T withSessionToken(String token) {
+    setSessionToken(token);
+    return (T) this;
+  }
+
+  @SneakyThrows(PasswordException.class)
+  private Credentials credentials() {
+    return SessionCredentials.builder()
+        .identity(Password.decode(ExternalResolver.resolve(getIdentity())))
+        .credential(Password.decode(ExternalResolver.resolve(getCredentials())))
+        .sessionToken(Password.decode(ExternalResolver.resolve(getSessionToken()))).build();
+  }
+}

--- a/interlok-jclouds-aws-sts/src/main/java/com/adaptris/jclouds/sts/package-info.java
+++ b/interlok-jclouds-aws-sts/src/main/java/com/adaptris/jclouds/sts/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Amazon STS specific credentials provider.
+ * 
+ * 
+ */
+package com.adaptris.jclouds.sts;

--- a/interlok-jclouds-aws-sts/src/test/java/com/adaptris/jclouds/sts/SessionTokenBuilderTest.java
+++ b/interlok-jclouds-aws-sts/src/test/java/com/adaptris/jclouds/sts/SessionTokenBuilderTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package com.adaptris.jclouds.sts;
+
+import static org.junit.Assert.assertNotNull;
+import org.jclouds.domain.Credentials;
+import org.junit.Test;
+import com.adaptris.jclouds.sts.SessionTokenCredentialsBuilder;
+import com.adaptris.security.exc.PasswordException;
+import com.google.common.base.Supplier;
+
+public class SessionTokenBuilderTest {
+
+
+  @Test
+  public void testBuild() throws Exception {
+    SessionTokenCredentialsBuilder builder = new SessionTokenCredentialsBuilder()
+        .withSessionToken("token")
+        .withCredentials("credentials").withIdentity("identity");
+    Supplier<Credentials> credentials = builder.build();
+    assertNotNull(credentials.get());
+  }
+
+  @Test(expected = PasswordException.class)
+  public void testBuild_SneakyPassword() throws Exception {
+    SessionTokenCredentialsBuilder builder = new SessionTokenCredentialsBuilder()
+        .withSessionToken("token").withCredentials("PW:X").withIdentity("identity");
+    Supplier<Credentials> credentials = builder.build();
+    credentials.get();
+  }
+}

--- a/interlok-jclouds-aws-sts/src/test/resources/unit-tests.properties
+++ b/interlok-jclouds-aws-sts/src/test/resources/unit-tests.properties
@@ -1,0 +1,4 @@
+ConsumerCase.baseDir=build/examples/consumers
+ServiceCase.baseDir=build/examples/services
+ProducerCase.baseDir=build/examples/producers
+WorkflowCase.baseDir=build/examples/workflows

--- a/interlok-jclouds-blobstore/src/main/java/com/adaptris/jclouds/blobstore/package-info.java
+++ b/interlok-jclouds-blobstore/src/main/java/com/adaptris/jclouds/blobstore/package-info.java
@@ -1,19 +1,24 @@
 /**
- * Interact with cloud provider blob storage via <a href="https://jclouds.apache.org">apache jclouds</a>.
+ * Interact with cloud provider blob storage via <a href="https://jclouds.apache.org">apache
+ * jclouds</a>.
  * 
  * <p>
- * All the providers supported by jclouds are listed on their <a href="https://jclouds.apache.org/reference/providers/">website</a>.
- * You should use that as the canonical reference. We have tested the blob storage with 3 different providers (the unit tests use
- * the filesystem provider); and the operations have been confirmed to work.
+ * All the providers supported by jclouds are listed on their
+ * <a href="https://jclouds.apache.org/reference/providers/">website</a>. You should use that as the
+ * canonical reference. We have tested the blob storage with 3 different providers (the unit tests
+ * use the filesystem provider); and the operations have been confirmed to work.
  * </p>
  * <ul>
- * <li>To access AWS-S3 via jclouds you will need to include the artefact {@code org.apache.jclouds.provider:aws-s3:2.1.0} and use
- * the provider {@code aws-s3}. This was tested for completeness, using the {@code interlok-aws-s3} optional component is generally
- * the better option.</li>
- * <li>To access Backblaze via jclouds you will need to include the artefact {@code org.apache.jclouds.provider:b2:2.1.0} and use
+ * <li>To access AWS-S3 via jclouds you will need to include the artefact
+ * {@code org.apache.jclouds.provider:aws-s3:XYZ}; where {@code XYZ} is the appropriate version; and
+ * use the provider {@code aws-s3}. This was tested for completeness, using the
+ * {@code interlok-aws-s3} optional component is generally the better option.</li>
+ * <li>To access Backblaze via jclouds you will need to include the artefact
+ * {@code org.apache.jclouds.provider:b2:XYZ}; where {@code XYZ} is the appropriate version; and use
  * the provider {@code b2}</li>
  * <li>To access MS Azure blob storage via jclouds you will need to include the artefact
- * {@code org.apache.jclouds.provider:azureblob:2.1.0} and use the provider {@code azureblob}</li>
+ * {@code org.apache.jclouds.provider:azureblob:XYZ}; where {@code XYZ} is the appropriate version;
+ * and use the provider {@code azureblob}</li>
  * </ul>
  * 
  */

--- a/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/BlobStoreServiceTest.java
+++ b/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/BlobStoreServiceTest.java
@@ -103,7 +103,9 @@ public class BlobStoreServiceTest extends ServiceCase {
   protected final List retrieveObjectsForSampleConfig() {
     ArrayList result = new ArrayList();
     for (OperationsBuilder b : OperationsBuilder.values()) {
-      result.add(new BlobStoreService(new BlobStoreConnection("aws-s3", exampleClientConfig()), b.build()));
+      result.add(new BlobStoreService(
+          new BlobStoreConnection().withProvider("aws-s3").withConfiguration(exampleClientConfig()),
+          b.build()));
     }
     return result;
   }

--- a/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/ConnectionTest.java
+++ b/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/ConnectionTest.java
@@ -15,47 +15,18 @@
 */
 package com.adaptris.jclouds.blobstore;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import org.jclouds.blobstore.BlobStore;
 import org.jclouds.blobstore.BlobStoreContext;
-import org.jclouds.filesystem.reference.FilesystemConstants;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.LifecycleHelper;
-import com.adaptris.util.KeyValuePair;
-import com.adaptris.util.KeyValuePairSet;
 
 public class ConnectionTest extends OperationCase {
 
-
-  @Before
-  public void setUp() throws Exception {
-
-  }
-
-  @After
-  public void tearDown() throws Exception {
-
-  }
-
   @Test
-  public void testConfiguration() throws Exception {
-    BlobStoreConnection con = new BlobStoreConnection();
-    assertNotNull(con.overrideConfiguration());
-    assertEquals(0, con.overrideConfiguration().size());
-    KeyValuePairSet cfg = new KeyValuePairSet();
-    cfg.add(new KeyValuePair(FilesystemConstants.PROPERTY_BASEDIR, "/tmp"));
-    con.setConfiguration(cfg);
-    assertNotNull(con.overrideConfiguration());
-    assertEquals(cfg, con.overrideConfiguration());
-  }
-
-  @Test
-  public void testConnection() throws Exception {
+  @SuppressWarnings("deprecation")
+  public void testConnection_LegacyCredentials() throws Exception {
     String name = guid.safeUUID();
     String container = guid.safeUUID();
     BlobStoreConnection con = createConnection();
@@ -74,30 +45,4 @@ public class ConnectionTest extends OperationCase {
     }
   }
 
-  @Test
-  public void testLifecycle() throws Exception {
-    String name = guid.safeUUID();
-    String container = guid.safeUUID();
-    BlobStoreConnection con = new BlobStoreConnection();
-    try {
-      LifecycleHelper.initAndStart(con);
-      fail();
-    } catch (CoreException expected) {
-
-    } finally {
-      LifecycleHelper.stopAndClose(con);
-    }
-    con = createConnection();
-    // will fail to decode
-    con.setIdentity("PW:x");
-    con.setCredentials("x");
-    try {
-      LifecycleHelper.initAndStart(con);
-      fail();
-    } catch (CoreException expected) {
-
-    } finally {
-      LifecycleHelper.stopAndClose(con);
-    }
-  }
 }

--- a/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/ListBlobServiceTest.java
+++ b/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/ListBlobServiceTest.java
@@ -30,7 +30,6 @@ import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.interlok.cloud.RemoteBlobFilterWrapper;
-import com.adaptris.util.KeyValuePairSet;
 
 public class ListBlobServiceTest extends ServiceCase {
   @Override
@@ -69,7 +68,7 @@ public class ListBlobServiceTest extends ServiceCase {
   public void testService_Failure() throws Exception {
     String container = OperationCase.guid.safeUUID();
     BlobStoreConnection con =
-        new BlobStoreConnection("how-can-this-provider-exist", new KeyValuePairSet());
+        new BlobStoreConnection().withProvider("how-can-this-provider-exist");
 
     ListBlobs service =
         new ListBlobs().withConnection(con).withOutputStyle(null).withContainer(container);
@@ -90,7 +89,8 @@ public class ListBlobServiceTest extends ServiceCase {
   protected ListBlobs retrieveObjectForSampleConfig() {
     try {
       return new ListBlobs()
-          .withConnection(new BlobStoreConnection("aws-s3", exampleClientConfig()))
+          .withConnection(new BlobStoreConnection().withProvider("aws-s3")
+              .withConfiguration(exampleClientConfig()))
           .withContainer("s3-bucket").withPrefix("prefix/or/path/if/you/prefer/")
           .withFilter(
               new RemoteBlobFilterWrapper().withFilterExpression(".*")

--- a/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/OperationCase.java
+++ b/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/OperationCase.java
@@ -36,7 +36,8 @@ public abstract class OperationCase {
   public static BlobStoreConnection createConnection() throws Exception {
     KeyValuePairSet config = new KeyValuePairSet();
     config.add(new KeyValuePair(FilesystemConstants.PROPERTY_BASEDIR, TempFileUtils.createTrackedDir(config).getCanonicalPath()));
-    BlobStoreConnection c = new BlobStoreConnection("filesystem", config);
+    BlobStoreConnection c =
+        new BlobStoreConnection().withProvider("filesystem").withConfiguration(config);
     return c;
   }
 

--- a/interlok-jclouds-common/build.gradle
+++ b/interlok-jclouds-common/build.gradle
@@ -1,11 +1,11 @@
 ext {
-  componentName='Interlok/Apache jclouds blobstore'
+  componentName='Interlok/Apache jclouds common components'
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
 }
 
 dependencies {
-  compile project(":interlok-jclouds-common")
-  compile ("org.apache.jclouds:jclouds-blobstore:$jcloudsVersion")
+  compile ("org.apache.jclouds:jclouds-core:$jcloudsVersion")
+  compile ("com.google.guava:guava:29.0-jre")
   testImplementation "org.apache.jclouds.api:filesystem:$jcloudsVersion"
 }
 
@@ -26,11 +26,6 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 
-task examplesJar(type: Jar, dependsOn: test) {
-    classifier = 'examples'
-    from new File(buildDir, '/examples')
-}
-
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
     from sourceSets.main.extensions.delombokTask
@@ -38,7 +33,6 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 
 artifacts {
   archives javadocJar
-  archives examplesJar
   archives sourcesJar
 }
 
@@ -48,18 +42,17 @@ publishing {
     mavenJava(MavenPublication) {
       from components.java
       artifact javadocJar { classifier "javadoc" }
-      artifact examplesJar { classifier "examples" }
       artifact sourcesJar { classifier "sources" }
       pom.withXml {
-        asNode().appendNode("description", "Use Apache jclouds to access your cloud storage")
+        asNode().appendNode("description", "Common classes for interacting with cloud providers via Apache JClouds")
         asNode().appendNode("name", componentName)
         def properties = asNode().appendNode("properties")
-        properties.appendNode("target", "3.7.3+")
-        properties.appendNode("tags", "s3,backblaze,azure blob,google cloud storage,rackspace")
+        properties.appendNode("target", "3.10.2+")
+        properties.appendNode("tags", "jclouds")
         properties.appendNode("license", "false")
         properties.appendNode("externalUrl", "https://jclouds.apache.org/")
         properties.appendNode("readme", "https://github.com/adaptris/interlok-jclouds/raw/develop/README.md")
-        properties.appendNode("repository", "https://github.com/adaptris/interlok-jclouds")   
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-jclouds")
       }
     }
   }
@@ -84,4 +77,3 @@ task deleteGeneratedFiles(type: Delete) {
 
 clean.dependsOn deleteGeneratedFiles
 javadoc.dependsOn offlinePackageList
-

--- a/interlok-jclouds-common/src/main/java/com/adaptris/jclouds/common/CredentialsBuilder.java
+++ b/interlok-jclouds-common/src/main/java/com/adaptris/jclouds/common/CredentialsBuilder.java
@@ -1,0 +1,14 @@
+package com.adaptris.jclouds.common;
+
+import org.jclouds.domain.Credentials;
+import com.google.common.base.Supplier;
+
+@FunctionalInterface
+public interface CredentialsBuilder {
+
+  /**
+   * Build the supplier of credentials.
+   * 
+   */
+  Supplier<Credentials> build();
+}

--- a/interlok-jclouds-common/src/main/java/com/adaptris/jclouds/common/DefaultCredentialsBuilder.java
+++ b/interlok-jclouds-common/src/main/java/com/adaptris/jclouds/common/DefaultCredentialsBuilder.java
@@ -1,0 +1,57 @@
+package com.adaptris.jclouds.common;
+
+import org.jclouds.domain.Credentials;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.interlok.resolver.ExternalResolver;
+import com.adaptris.security.exc.PasswordException;
+import com.adaptris.security.password.Password;
+import com.google.common.base.Supplier;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.SneakyThrows;
+
+/**
+ * Default implementation of {@link CredentialsBuilder} for use with jclouds.
+ *
+ */
+@XStreamAlias("jclouds-default-credentials-builder")
+public class DefaultCredentialsBuilder implements CredentialsBuilder {
+  /**
+   * Set the identity used to connect to the storage provider, generally the access key.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(style = "PASSWORD", external = true)
+  private String identity;
+  /**
+   * Set any credentials that are required, generally the secret key.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(style = "PASSWORD", external = true)
+  private String credentials;
+
+  @Override
+  public Supplier<Credentials> build() {
+    return () -> credentials();
+  }
+
+  @SneakyThrows(PasswordException.class)
+  private Credentials credentials() {
+    return new Credentials(Password.decode(ExternalResolver.resolve(getIdentity())),
+        Password.decode(ExternalResolver.resolve(getCredentials())));
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends DefaultCredentialsBuilder> T withIdentity(String id) {
+    setIdentity(id);
+    return (T) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends DefaultCredentialsBuilder> T withCredentials(String s) {
+    setCredentials(s);
+    return (T) this;
+  }
+}

--- a/interlok-jclouds-common/src/main/java/com/adaptris/jclouds/common/JcloudsConnection.java
+++ b/interlok-jclouds-common/src/main/java/com/adaptris/jclouds/common/JcloudsConnection.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2018 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package com.adaptris.jclouds.common;
+
+import java.util.Optional;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import org.apache.commons.lang3.ObjectUtils;
+import org.jclouds.ContextBuilder;
+import com.adaptris.core.AdaptrisConnectionImp;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.util.Args;
+import com.adaptris.util.KeyValuePairBag;
+import com.adaptris.util.KeyValuePairSet;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Connection for interactions via apache jclouds.
+ * 
+ * 
+ * @config jclouds-blobstore-connection
+ *
+ */
+@NoArgsConstructor
+public abstract class JcloudsConnection extends AdaptrisConnectionImp {
+
+  /**
+   * The supplier for the any credentials.
+   * 
+   */
+  @Getter
+  @Setter
+  @Valid
+  private CredentialsBuilder credentialsBuilder;
+
+  /**
+   * The underlying provider.
+   * <p>
+   * The value specified here will be passed into {@code ContextBuilder#newBuilder(String)} without
+   * any validation. Since jclouds is pluggable; please check
+   * <a href="http://jclouds.apache.org/reference/providers/">their documentation</a> for the list
+   * of supported providers. Please note that individual providers may require additional jars that
+   * will not be delivered as part of the standard distribution.
+   * </p>
+   */
+  @NotBlank
+  @Getter
+  @Setter
+  private String provider;
+
+  /**
+   * Set any overrides that are required.
+   * <p>
+   * These properties will be passed through to
+   * {@link ContextBuilder#overrides(java.util.Properties)}.
+   * </p>
+   * 
+   */
+  @Getter
+  @Setter
+  @Valid
+  private KeyValuePairSet configuration = new KeyValuePairSet();
+  
+  @Override
+  protected void prepareConnection() throws CoreException {
+    Args.notBlank(getProvider(), "provider");
+  }
+
+  protected ContextBuilder newContextBuilder() {
+    ContextBuilder builder = ContextBuilder.newBuilder(getProvider());
+    builder.overrides(KeyValuePairBag.asProperties(overrideConfiguration()));
+    credentialsBuilder().ifPresent((credentials) -> {
+      builder.credentialsSupplier(credentials.build());
+    });
+    return builder;
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends JcloudsConnection> T withCredentials(CredentialsBuilder b) {
+    setCredentialsBuilder(b);
+    return (T) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends JcloudsConnection> T withConfiguration(KeyValuePairSet cfg) {
+    setConfiguration(cfg);
+    return (T) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends JcloudsConnection> T withProvider(String provider) {
+    setProvider(provider);
+    return (T) this;
+  }
+
+
+  protected Optional<CredentialsBuilder> credentialsBuilder() {
+    return Optional.ofNullable(getCredentialsBuilder());
+  }
+
+
+  protected KeyValuePairSet overrideConfiguration() {
+    return ObjectUtils.defaultIfNull(getConfiguration(), new KeyValuePairSet());
+  }
+}

--- a/interlok-jclouds-common/src/main/java/com/adaptris/jclouds/common/package-info.java
+++ b/interlok-jclouds-common/src/main/java/com/adaptris/jclouds/common/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * Common classes for interacting with external provides via
+ * <a href="https://jclouds.apache.org">apache jclouds</a>.
+ * 
+ * <p>
+ * All the providers supported by jclouds are listed on their
+ * <a href="https://jclouds.apache.org/reference/providers/">website</a>. You should use that as the
+ * canonical reference.
+ * </p>
+ * 
+ */
+package com.adaptris.jclouds.common;

--- a/interlok-jclouds-common/src/test/java/com/adaptris/jclouds/common/ConnectionTest.java
+++ b/interlok-jclouds-common/src/test/java/com/adaptris/jclouds/common/ConnectionTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package com.adaptris.jclouds.common;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import org.jclouds.filesystem.reference.FilesystemConstants;
+import org.junit.Test;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.stubs.TempFileUtils;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.util.KeyValuePair;
+import com.adaptris.util.KeyValuePairSet;
+
+public class ConnectionTest {
+
+  @Test
+  public void testConfiguration() throws Exception {
+    MyJcloudsConnection con = new MyJcloudsConnection();
+    assertNotNull(con.overrideConfiguration());
+    assertEquals(0, con.overrideConfiguration().size());
+    KeyValuePairSet cfg = new KeyValuePairSet();
+    cfg.add(new KeyValuePair(FilesystemConstants.PROPERTY_BASEDIR, "/tmp"));
+    con.withConfiguration(cfg);
+    assertNotNull(con.overrideConfiguration());
+    assertEquals(cfg, con.overrideConfiguration());
+  }
+
+  @Test
+  public void testLifecycle() throws Exception {
+    JcloudsConnection con = createConnection();
+    try {
+      LifecycleHelper.initAndStart(con);
+      assertFalse(con.credentialsBuilder().isPresent());
+      assertNotNull(con.newContextBuilder());
+    } finally {
+      LifecycleHelper.stopAndClose(con);
+    }
+  }
+
+  @Test
+  public void testLifecycle_WithCredentials() throws Exception {
+    JcloudsConnection con = createConnection()
+        .withCredentials(new DefaultCredentialsBuilder().withCredentials("c").withIdentity("i"));
+    try {
+      LifecycleHelper.initAndStart(con);
+      assertTrue(con.credentialsBuilder().isPresent());
+      assertNotNull(con.newContextBuilder());
+
+    } finally {
+      LifecycleHelper.stopAndClose(con);
+    }
+  }
+
+  public static JcloudsConnection createConnection() throws Exception {
+    KeyValuePairSet config = new KeyValuePairSet();
+    config.add(new KeyValuePair(FilesystemConstants.PROPERTY_BASEDIR,
+        TempFileUtils.createTrackedDir(config).getCanonicalPath()));
+    MyJcloudsConnection c =
+        new MyJcloudsConnection().withConfiguration(config).withCredentials(null)
+            .withProvider("filesystem");
+    return c;
+  }
+
+  private static class MyJcloudsConnection extends JcloudsConnection {
+    @Override
+    protected void initConnection() throws CoreException {
+    }
+
+    @Override
+    protected void startConnection() throws CoreException {
+    }
+
+    @Override
+    protected void stopConnection() {
+    }
+
+    @Override
+    protected void closeConnection() {
+    }
+  }
+
+}

--- a/interlok-jclouds-common/src/test/java/com/adaptris/jclouds/common/DefaultCredentialsBuilderTest.java
+++ b/interlok-jclouds-common/src/test/java/com/adaptris/jclouds/common/DefaultCredentialsBuilderTest.java
@@ -1,0 +1,26 @@
+package com.adaptris.jclouds.common;
+
+import static org.junit.Assert.assertNotNull;
+import org.jclouds.domain.Credentials;
+import org.junit.Test;
+import com.adaptris.security.exc.PasswordException;
+import com.google.common.base.Supplier;
+
+public class DefaultCredentialsBuilderTest {
+
+  @Test
+  public void testBuild() throws Exception {
+    DefaultCredentialsBuilder builder =
+        new DefaultCredentialsBuilder().withCredentials("credentials").withIdentity("identity");
+    Supplier<Credentials> credentials = builder.build();
+    assertNotNull(credentials.get());
+  }
+
+  @Test(expected = PasswordException.class)
+  public void testBuild_SneakyPassword() throws Exception {
+    DefaultCredentialsBuilder builder =
+        new DefaultCredentialsBuilder().withCredentials("PW:X").withIdentity("identity");
+    Supplier<Credentials> credentials = builder.build();
+    credentials.get();
+  }
+}

--- a/interlok-jclouds-common/src/test/resources/unit-tests.properties
+++ b/interlok-jclouds-common/src/test/resources/unit-tests.properties
@@ -1,0 +1,4 @@
+ConsumerCase.baseDir=build/examples/consumers
+ServiceCase.baseDir=build/examples/services
+ProducerCase.baseDir=build/examples/producers
+WorkflowCase.baseDir=build/examples/workflows

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'interlok-jclouds'
+include 'interlok-jclouds-common'
+include 'interlok-jclouds-aws-sts'
 include 'interlok-jclouds-blobstore'
-


### PR DESCRIPTION
## Motivation

If your AWS cloud is configured to use session tokens then interlok-jclouds-blobstore can't be used to authenticate against AWS since it currently only supports static identity + credentials.

If you don't configure any authentication then since jclouds doesn't use the AWS SDK under the covers (you can see this by depending on  `org.apache.jclouds.provider:aws-s3` and running a dependency check; then it _probably_ doesn't make use of the standard AWS mechanisms (`~/.aws` or environment variables). 

## Modification

- Add a new interlok-jclouds-common submodule that contains
    - CredentialsBuilder interface, with a default builder that takes identity + credentials
    - Abstracted JcloudsConnection that handles the credentials and key-value configuration
- Add a new interlok-jclouds-aws-sts submodule that contains
    - SessionTokenCredentialsBuilder which uses SessionCredentials from the `org.apache.jclouds.api:sts` package.
- Deprecate identity + credentials from BlobstoreConnection
- Make BlobstoreConnection extend JcloudsConnection

## Result

- Existing configuration which now log a warning:

```xml
      <jclouds-blobstore-connection>
        <unique-id>jclouds-b2</unique-id>
        <provider>b2</provider>
        <identity>${b2.access.key}</identity>
        <credentials>${b2.secret.key}</credentials>
      </jclouds-blobstore-connection>
```
```
WARN  [JMX-Request-0] [c.a.c.u.LoggingHelper] [BlobStoreConnection(jclouds-b2)] uses static credentials/identity, use a credentials-builder instead
```
- identity/credentials now only exist as AdvancedConfig(rare=true) configuration options.

```xml
<jclouds-blobstore-connection>
  <unique-id>jclouds-b2</unique-id>
  <credentials-builder class="jclouds-default-credentials-builder">
        <identity>${b2.access.key}</identity>
        <credentials>${b2.secret.key}</credentials>
  </credentials-builder>
  <provider>b2</provider>
  <configuration/>
</jclouds-blobstore-connection>
```

Is now the preferred configuration.

## Testing

Tested using configuration variants as above against backblaze using `org.apache.jclouds.provider:b2`

Testing against AWS S3 will require `org.apache.jclouds.provider:aws-s3:XYZ`

