### PR TITLE
INTERLOK-3559 Deprecation removal

### DIFF
--- a/interlok-jclouds-aws-sts/src/test/java/com/adaptris/jclouds/sts/SessionTokenBuilderTest.java
+++ b/interlok-jclouds-aws-sts/src/test/java/com/adaptris/jclouds/sts/SessionTokenBuilderTest.java
@@ -16,9 +16,10 @@
 package com.adaptris.jclouds.sts;
 
 import static org.junit.Assert.assertNotNull;
+
 import org.jclouds.domain.Credentials;
 import org.junit.Test;
-import com.adaptris.jclouds.sts.SessionTokenCredentialsBuilder;
+
 import com.adaptris.security.exc.PasswordException;
 import com.google.common.base.Supplier;
 

--- a/interlok-jclouds-blobstore/src/main/java/com/adaptris/jclouds/blobstore/ListOperation.java
+++ b/interlok-jclouds-blobstore/src/main/java/com/adaptris/jclouds/blobstore/ListOperation.java
@@ -15,30 +15,19 @@
 */
 package com.adaptris.jclouds.blobstore;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Optional;
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.jclouds.blobstore.BlobStore;
-import org.jclouds.blobstore.domain.PageSet;
-import org.jclouds.blobstore.domain.StorageMetadata;
-import org.jclouds.blobstore.domain.StorageType;
 import org.jclouds.blobstore.options.ListContainerOptions;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.interlok.cloud.BlobListRenderer;
-import com.adaptris.interlok.cloud.RemoteBlob;
 import com.adaptris.interlok.cloud.RemoteBlobFilter;
-import com.adaptris.interlok.util.CloseableIterable;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
 

--- a/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/BlobStoreServiceTest.java
+++ b/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/BlobStoreServiceTest.java
@@ -16,16 +16,19 @@
 package com.adaptris.jclouds.blobstore;
 
 import static org.junit.Assert.fail;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import org.junit.Test;
+
 import com.adaptris.core.CoreException;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
 
-public class BlobStoreServiceTest extends ServiceCase {
+public class BlobStoreServiceTest extends ExampleServiceCase {
   private static final String HYPHEN = "-";
 
   private enum OperationsBuilder {
@@ -69,10 +72,7 @@ public class BlobStoreServiceTest extends ServiceCase {
     };
     abstract Operation build();
   }
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
+
   @Test
   public void testLifecycle() throws Exception {
     BlobStoreService service = new BlobStoreService();
@@ -100,8 +100,8 @@ public class BlobStoreServiceTest extends ServiceCase {
   }
 
   @Override
-  protected final List retrieveObjectsForSampleConfig() {
-    ArrayList result = new ArrayList();
+  protected final List<?> retrieveObjectsForSampleConfig() {
+    ArrayList<BlobStoreService> result = new ArrayList<>();
     for (OperationsBuilder b : OperationsBuilder.values()) {
       result.add(new BlobStoreService(
           new BlobStoreConnection().withProvider("aws-s3").withConfiguration(exampleClientConfig()),

--- a/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/CheckExistsTest.java
+++ b/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/CheckExistsTest.java
@@ -15,9 +15,9 @@
 */
 package com.adaptris.jclouds.blobstore;
 
-import org.jclouds.blobstore.BlobStore;
 import org.jclouds.blobstore.BlobStoreContext;
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceException;
@@ -36,7 +36,7 @@ public class CheckExistsTest extends OperationCase {
     try {
       LifecycleHelper.initAndStart(service);
       BlobStoreContext ctx = con.getBlobStoreContext();
-      BlobStore store = ctx.getBlobStore();
+      ctx.getBlobStore();
       createBlob(ctx, container, name, "hello world");
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("");
       service.doService(msg);
@@ -54,7 +54,7 @@ public class CheckExistsTest extends OperationCase {
     try {
       LifecycleHelper.initAndStart(service);
       BlobStoreContext ctx = con.getBlobStoreContext();
-      BlobStore store = ctx.getBlobStore();
+      ctx.getBlobStore();
       createBlob(ctx, container, name, "hello world");
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("");
       service.doService(msg);

--- a/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/ConnectionTest.java
+++ b/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/ConnectionTest.java
@@ -16,26 +16,32 @@
 package com.adaptris.jclouds.blobstore;
 
 import static org.junit.Assert.fail;
-import org.jclouds.blobstore.BlobStore;
+
 import org.jclouds.blobstore.BlobStoreContext;
 import org.junit.Test;
+
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.jclouds.common.CredentialsBuilder;
+import com.adaptris.jclouds.common.DefaultCredentialsBuilder;
 
 public class ConnectionTest extends OperationCase {
 
   @Test
-  @SuppressWarnings("deprecation")
   public void testConnection_LegacyCredentials() throws Exception {
-    String name = guid.safeUUID();
     String container = guid.safeUUID();
+    
+    CredentialsBuilder credentialsBuilder = new DefaultCredentialsBuilder()
+            .withIdentity("x")
+            .withCredentials("x");
+
     BlobStoreConnection con = createConnection();
-    con.setIdentity("x");
-    con.setCredentials("x");
+    con.setCredentialsBuilder(credentialsBuilder);
+    
     LifecycleHelper.initAndStart(con);
     try {
       BlobStoreContext ctx = con.getBlobStoreContext();
-      BlobStore store = ctx.getBlobStore();
+      ctx.getBlobStore();
       con.getBlobStore(container);
       fail();
     } catch (CoreException expected) {

--- a/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/ListBlobServiceTest.java
+++ b/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/ListBlobServiceTest.java
@@ -19,23 +19,23 @@ import static com.adaptris.jclouds.blobstore.OperationCase.createBlob;
 import static com.adaptris.jclouds.blobstore.OperationCase.createConnection;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+
 import java.io.StringReader;
 import java.util.List;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.interlok.cloud.RemoteBlobFilterWrapper;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 
-public class ListBlobServiceTest extends ServiceCase {
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
+public class ListBlobServiceTest extends ExampleServiceCase {
+
   @Test
   public void testService() throws Exception {
     String container = OperationCase.guid.safeUUID();

--- a/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/ListBlobsTest.java
+++ b/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/ListBlobsTest.java
@@ -129,7 +129,6 @@ public class ListBlobsTest extends OperationCase {
 
     BlobStoreConnection con = mock(BlobStoreConnection.class);
     BlobStore blobstore = mock(BlobStore.class);
-    Set<StorageMetadata> wrappedList = createBlobList();
     MyPageSet bloblist = new MyPageSet(createBlobList());
     when(con.retrieveConnection(any())).thenReturn(con);
     when(con.getBlobStore(any())).thenReturn(blobstore);
@@ -154,13 +153,13 @@ public class ListBlobsTest extends OperationCase {
   private Set<StorageMetadata> createBlobList() {
     HashSet<StorageMetadata> result = new HashSet<>();
     result.add(new StorageMetadataImpl(StorageType.FOLDER, null, "myFolder", null, null, null,
-        new Date(), new Date(), Collections.EMPTY_MAP, 0L, Tier.STANDARD));
+        new Date(), new Date(), Collections.emptyMap(), 0L, Tier.STANDARD));
     result.add(new StorageMetadataImpl(StorageType.BLOB, null, "jsonfile.json", null, null, null,
-        new Date(), new Date(), Collections.EMPTY_MAP, 0L, Tier.STANDARD));
+        new Date(), new Date(), Collections.emptyMap(), 0L, Tier.STANDARD));
     result.add(new StorageMetadataImpl(StorageType.BLOB, null, "file.csv", null, null, null,
-        new Date(), new Date(), Collections.EMPTY_MAP, 0L, Tier.STANDARD));
+        new Date(), new Date(), Collections.emptyMap(), 0L, Tier.STANDARD));
     result.add(new StorageMetadataImpl(StorageType.BLOB, null, "README.txt", null, null, null,
-        new Date(), new Date(), Collections.EMPTY_MAP, 0L, Tier.STANDARD));
+        new Date(), new Date(), Collections.emptyMap(), 0L, Tier.STANDARD));
     return result;
   }
 

--- a/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/RemoteBlobIterableTest.java
+++ b/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/RemoteBlobIterableTest.java
@@ -25,7 +25,7 @@ public class RemoteBlobIterableTest extends OperationCase {
       int count = 0;
       assertTrue(i.hasNext());
       while (i.hasNext()) {
-        RemoteBlob blob = i.next();
+        i.next();
         count++;        
       }
       assertEquals(10, count);


### PR DESCRIPTION
## Motivation

Part of the deprecation removal process for V4.

## Modification

Removed the basic credentials from the blob store connection, you must now use a credentials builder, which already exists.

Then fixed up a few minor warnings with unused imports, vars etc.

EDIT: Not yet tested in the UI that will come with the V4 pre testing.

## Result

A fairly clean project with no deprecation warnings.
