### PR TITLE
INTERLOK-3752 Exception when running list blobs with aws s3 prefix

### DIFF
--- a/interlok-jclouds-blobstore/src/main/java/com/adaptris/jclouds/blobstore/RemoteBlobIterable.java
+++ b/interlok-jclouds-blobstore/src/main/java/com/adaptris/jclouds/blobstore/RemoteBlobIterable.java
@@ -1,8 +1,10 @@
 package com.adaptris.jclouds.blobstore;
 
+import java.util.Date;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jclouds.blobstore.BlobStore;
@@ -10,6 +12,7 @@ import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.domain.StorageType;
 import org.jclouds.blobstore.options.ListContainerOptions;
+
 import com.adaptris.interlok.cloud.RemoteBlob;
 import com.adaptris.interlok.cloud.RemoteBlobFilter;
 import com.adaptris.interlok.cloud.RemoteBlobIterableImpl;
@@ -25,10 +28,10 @@ class RemoteBlobIterable extends RemoteBlobIterableImpl<StorageMetadata> {
   private Iterator<? extends StorageMetadata> pageIterator;
 
   protected RemoteBlobIterable(BlobStore store, String container, String prefix, RemoteBlobFilter filter) {
-    this.blobStorage = store;
-    this.containerName = container;
-    this.blobPrefix = prefix;
-    this.blobFilter = filter;
+    blobStorage = store;
+    containerName = container;
+    blobPrefix = prefix;
+    blobFilter = filter;
   }
 
   @Override
@@ -44,7 +47,7 @@ class RemoteBlobIterable extends RemoteBlobIterableImpl<StorageMetadata> {
     }
     return Optional.ofNullable(pageIterator.next());
   }
-  
+
   private void advanceToNextPage() throws NoSuchElementException {
     String hasNextPage = currentPage.getNextMarker();
     if (hasNextPage == null) {
@@ -53,16 +56,20 @@ class RemoteBlobIterable extends RemoteBlobIterableImpl<StorageMetadata> {
     currentPage = blobStorage.list(containerName, buildListOptions(blobPrefix, hasNextPage));
     pageIterator = currentPage.iterator();
   }
-  
+
   @Override
   protected Optional<RemoteBlob> accept(StorageMetadata meta) {
-    RemoteBlob blob = new RemoteBlob.Builder().setBucket(containerName).setLastModified(meta.getLastModified().getTime())
+    RemoteBlob blob = new RemoteBlob.Builder().setBucket(containerName).setLastModified(lastModified(meta))
         .setName(meta.getName()).setSize(NumberUtils.toLongDefaultIfNull(meta.getSize(), -1)).build();
     // Only accept if it's a blob, rather than a directory or similar.
     if (BooleanUtils.and(new boolean[] {blobFilter.accept(blob), meta.getType() == StorageType.BLOB})) {
       return Optional.of(blob);
     }
-    return Optional.empty();      
+    return Optional.empty();
+  }
+
+  static long lastModified(StorageMetadata meta) {
+    return Optional.ofNullable(meta.getLastModified()).map(Date::getTime).orElseGet(() -> -1L);
   }
 
   private ListContainerOptions buildListOptions(String prefix, String marker) {

--- a/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/RemoteBlobIterableTest.java
+++ b/interlok-jclouds-blobstore/src/test/java/com/adaptris/jclouds/blobstore/RemoteBlobIterableTest.java
@@ -2,15 +2,22 @@ package com.adaptris.jclouds.blobstore;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.Date;
 import java.util.Iterator;
+
 import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.domain.StorageType;
+import org.jclouds.blobstore.domain.Tier;
+import org.jclouds.blobstore.domain.internal.StorageMetadataImpl;
 import org.junit.Test;
+
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.interlok.cloud.RemoteBlob;
 
 public class RemoteBlobIterableTest extends OperationCase {
 
-  
   @Test
   public void testIterator() throws Exception {
     String container = guid.safeUUID();
@@ -26,7 +33,7 @@ public class RemoteBlobIterableTest extends OperationCase {
       assertTrue(i.hasNext());
       while (i.hasNext()) {
         i.next();
-        count++;        
+        count++;
       }
       assertEquals(10, count);
     } finally {
@@ -51,5 +58,26 @@ public class RemoteBlobIterableTest extends OperationCase {
       LifecycleHelper.stopAndClose(con);
     }
   }
-  
+
+  @Test
+  public void testLastModified() {
+    Date date = new Date();
+    StorageMetadataImpl meta = new StorageMetadataImpl(StorageType.FOLDER, "id", "name", null, null, "eTag", date, date,
+        Collections.emptyMap(), null, Tier.STANDARD);
+
+    long lastModified = RemoteBlobIterable.lastModified(meta);
+
+    assertEquals(date.getTime(), lastModified);
+  }
+
+  @Test
+  public void testLastModifiedNull() {
+    StorageMetadataImpl meta = new StorageMetadataImpl(StorageType.FOLDER, "id", "name", null, null, "eTag", new Date(),
+        null, Collections.emptyMap(), null, Tier.STANDARD);
+
+    long lastModified = RemoteBlobIterable.lastModified(meta);
+
+    assertEquals(-1L, lastModified);
+  }
+
 }

--- a/interlok-jclouds-common/src/main/java/com/adaptris/jclouds/common/DefaultCredentialsBuilder.java
+++ b/interlok-jclouds-common/src/main/java/com/adaptris/jclouds/common/DefaultCredentialsBuilder.java
@@ -1,12 +1,16 @@
 package com.adaptris.jclouds.common;
 
 import org.jclouds.domain.Credentials;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.interlok.resolver.ExternalResolver;
 import com.adaptris.security.exc.PasswordException;
 import com.adaptris.security.password.Password;
 import com.google.common.base.Supplier;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.SneakyThrows;
@@ -16,6 +20,8 @@ import lombok.SneakyThrows;
  *
  */
 @XStreamAlias("jclouds-default-credentials-builder")
+@DisplayOrder(order = { "identity", "credentials" })
+@ComponentProfile(summary = "Provide credentials")
 public class DefaultCredentialsBuilder implements CredentialsBuilder {
   /**
    * Set the identity used to connect to the storage provider, generally the access key.


### PR DESCRIPTION
## Motivation

An exception is thrown when running list blobs service against an AWS S3 bucket containing folders.

## Modification

- Return -1 when the StorageMetadata last modified date is null (folder in aws s3).
- Add a couple of tests for the change.
- Add DisplayOrder annotation for DefaultCredentialsBuilder.

## Result

We can use Jclouds with AWS S3 with some folders.

## Testing

The tests should pass.

In AWS S3, have a bucket with at least a folder.

Build an instance of Interlok following: https://gitlab.agb.rbxd.ds/interlok/testing/jclouds-testing

Replace. interlok-jclouds-blobstore with the one built from the PR's branch.

Start the adapter and run `curl "http://localhost:8080/api/s3/"`
This should return the list of files in the bucket.

